### PR TITLE
Fix(#105): 커플 배너 이미지 URL에 Ncp 주소가 붙어오도록 수정한다

### DIFF
--- a/src/main/java/com/meetup/hereandnow/connect/application/info/CoupleInfoSearchService.java
+++ b/src/main/java/com/meetup/hereandnow/connect/application/info/CoupleInfoSearchService.java
@@ -5,6 +5,7 @@ import com.meetup.hereandnow.connect.dto.response.CoupleCourseBannerResponseDto;
 import com.meetup.hereandnow.connect.dto.response.CoupleInfoResponseDto;
 import com.meetup.hereandnow.connect.exception.CoupleErrorCode;
 import com.meetup.hereandnow.connect.infrastructure.repository.CoupleRepository;
+import com.meetup.hereandnow.connect.infrastructure.strategy.CourseImageSelector;
 import com.meetup.hereandnow.core.infrastructure.objectstorage.ObjectStorageService;
 import com.meetup.hereandnow.core.util.SecurityUtils;
 import com.meetup.hereandnow.course.domain.entity.Course;
@@ -27,6 +28,7 @@ public class CoupleInfoSearchService {
     private final CoupleRepository coupleRepository;
     private final CourseRepository courseRepository;
     private final ObjectStorageService objectStorageService;
+    private final CourseImageSelector courseImageSelector;
 
     @Transactional
     public CoupleInfoResponseDto getCoupleInfoResponse() {
@@ -76,20 +78,8 @@ public class CoupleInfoSearchService {
 
         List<CoupleCourseBannerResponseDto> bannerList = courseList.stream()
                 .map(course -> {
-                    CoupleCourseBannerResponseDto dto = CoupleCourseBannerResponseDto.from(course);
-
-                    String finalUrl = dto.thumbnailImageLink() != null
-                            ? objectStorageService.buildImageUrl(dto.thumbnailImageLink())
-                            : null;
-
-                    return new CoupleCourseBannerResponseDto(
-                            dto.courseId(),
-                            dto.startDate(),
-                            dto.courseTitle(),
-                            dto.courseDescription(),
-                            dto.placeCount(),
-                            finalUrl
-                    );
+                    String thumbnailImageLink = courseImageSelector.selectFirstImage(course);
+                    return CoupleCourseBannerResponseDto.from(course, thumbnailImageLink);
                 })
                 .toList();
 

--- a/src/main/java/com/meetup/hereandnow/connect/dto/response/CoupleCourseBannerResponseDto.java
+++ b/src/main/java/com/meetup/hereandnow/connect/dto/response/CoupleCourseBannerResponseDto.java
@@ -3,6 +3,7 @@ package com.meetup.hereandnow.connect.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.meetup.hereandnow.course.domain.entity.Course;
+import com.meetup.hereandnow.pin.domain.entity.PinImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
@@ -28,7 +29,7 @@ public record CoupleCourseBannerResponseDto(
         String thumbnailImageLink
 ) {
         public static CoupleCourseBannerResponseDto from(
-                Course course
+                Course course, String imageUrl
         ) {
                 return new CoupleCourseBannerResponseDto(
                         course.getId(),
@@ -36,7 +37,7 @@ public record CoupleCourseBannerResponseDto(
                         course.getCourseTitle(),
                         course.getCourseDescription(),
                         course.getPinList().size(),
-                        course.getPinList().getFirst().getPinImages().getFirst().getImageUrl()
+                        imageUrl
                 );
         }
 

--- a/src/main/java/com/meetup/hereandnow/connect/infrastructure/strategy/CourseImageSelector.java
+++ b/src/main/java/com/meetup/hereandnow/connect/infrastructure/strategy/CourseImageSelector.java
@@ -34,5 +34,13 @@ public class CourseImageSelector {
                 .limit(MAX_IMAGE_COUNT)
                 .toList();
     }
+
+    public String selectFirstImage(Course course) {
+        return course.getPinList().stream()
+                .flatMap(pin -> pin.getPinImages().stream())
+                .findFirst()
+                .map(pinImage -> objectStorageService.buildImageUrl(pinImage.getImageUrl()))
+                .orElse(null);
+    }
 }
 

--- a/src/test/java/com/meetup/hereandnow/connect/application/info/CoupleInfoSearchServiceTest.java
+++ b/src/test/java/com/meetup/hereandnow/connect/application/info/CoupleInfoSearchServiceTest.java
@@ -5,6 +5,7 @@ import com.meetup.hereandnow.connect.dto.response.CoupleCourseBannerResponseDto;
 import com.meetup.hereandnow.connect.dto.response.CoupleInfoResponseDto;
 import com.meetup.hereandnow.connect.exception.CoupleErrorCode;
 import com.meetup.hereandnow.connect.infrastructure.repository.CoupleRepository;
+import com.meetup.hereandnow.connect.infrastructure.strategy.CourseImageSelector;
 import com.meetup.hereandnow.core.exception.DomainException;
 import com.meetup.hereandnow.core.util.SecurityUtils;
 import com.meetup.hereandnow.course.domain.entity.Course;
@@ -46,6 +47,9 @@ class CoupleInfoSearchServiceTest {
 
     @Mock
     private CourseRepository courseRepository;
+
+    @Mock
+    private CourseImageSelector courseImageSelector;
 
     @InjectMocks
     private CoupleInfoSearchService coupleInfoSearchService;
@@ -164,6 +168,8 @@ class CoupleInfoSearchServiceTest {
             when(coupleRepository.findByMember(member1)).thenReturn(Optional.of(couple));
             when(courseRepository.findByCourseVisitMemberAndMemberIn(eq("연인"), anyList()))
                     .thenReturn(courseList);
+            when(courseImageSelector.selectFirstImage(any(Course.class)))
+                    .thenReturn("course/1/pin_0_image_0.jpg");
 
             // when
             Slice<CoupleCourseBannerResponseDto> result =
@@ -199,8 +205,6 @@ class CoupleInfoSearchServiceTest {
             assertThat(result).isNotNull();
             assertThat(result.getContent()).isEmpty();
             assertThat(result.hasNext()).isFalse();
-            CoupleCourseBannerResponseDto coupleCourseBannerResponseDto = result.getContent().getFirst();
-            System.out.println(coupleCourseBannerResponseDto.thumbnailImageLink());
 
             verify(coupleRepository).findByMember(member1);
         }
@@ -231,6 +235,8 @@ class CoupleInfoSearchServiceTest {
             when(coupleRepository.findByMember(member1)).thenReturn(Optional.of(couple));
             when(courseRepository.findByCourseVisitMemberAndMemberIn(eq("연인"), anyList()))
                     .thenReturn(courseList);
+            when(courseImageSelector.selectFirstImage(any(Course.class)))
+                    .thenReturn("course/1/pin_0_image_0.jpg");
 
             // when
             Slice<CoupleCourseBannerResponseDto> result =

--- a/src/test/java/com/meetup/hereandnow/connect/infrastructure/strategy/CourseImageSelectorTest.java
+++ b/src/test/java/com/meetup/hereandnow/connect/infrastructure/strategy/CourseImageSelectorTest.java
@@ -2,89 +2,140 @@ package com.meetup.hereandnow.connect.infrastructure.strategy;
 
 import com.meetup.hereandnow.core.infrastructure.objectstorage.ObjectStorageService;
 import com.meetup.hereandnow.course.domain.entity.Course;
+import com.meetup.hereandnow.member.domain.Member;
 import com.meetup.hereandnow.pin.domain.entity.Pin;
 import com.meetup.hereandnow.pin.domain.entity.PinImage;
+import com.meetup.hereandnow.place.domain.Place;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CourseImageSelector 테스트")
 class CourseImageSelectorTest {
 
-    private final CourseImageSelector courseImageSelector = new CourseImageSelector(new ObjectStorageService());
+    @Mock
+    private ObjectStorageService objectStorageService;
+
+    @InjectMocks
+    private CourseImageSelector courseImageSelector;
+
+    private Member member;
+    private Place place;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .id(1L)
+                .build();
+
+        place = Place.builder()
+                .id(1L)
+                .placeName("테스트 장소")
+                .build();
+    }
 
     @Test
-    @DisplayName("최대 3개의 랜덤 이미지를 선택한다")
-    void success_max_3_image_in_list() {
+    @DisplayName("코스에 이미지가 없으면 빈 리스트를 반환한다")
+    void selectRandomImages_WhenNoImages_ReturnsEmptyList() {
         // given
-        PinImage image1 = createPinImage("image1.jpg");
-        PinImage image2 = createPinImage("image2.jpg");
-        PinImage image3 = createPinImage("image3.jpg");
-        PinImage image4 = createPinImage("image4.jpg");
-        PinImage image5 = createPinImage("image5.jpg");
+        Course course = Course.builder()
+                .id(1L)
+                .member(member)
+                .courseVisitDate(LocalDate.now())
+                .courseVisitMember("테스트 유저")
+                .courseRegion("서울")
+                .courseDescription("테스트 코스")
+                .pinList(new ArrayList<>())
+                .build();
 
-        Pin pin = createPin(List.of(image1, image2, image3, image4, image5));
-        Course course = createCourse(List.of(pin));
+        // when
+        List<String> result = courseImageSelector.selectRandomImages(course);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(objectStorageService, times(0)).buildImageUrl(anyString());
+    }
+
+    @Test
+    @DisplayName("코스에 이미지가 3개 미만이면 모든 이미지를 반환한다")
+    void selectRandomImages_WhenLessThan3Images_ReturnsAllImages() {
+        // given
+        Course course = createCourseWithPins(2, 1); // 2개의 핀, 각 핀에 1개의 이미지
+
+        given(objectStorageService.buildImageUrl(anyString()))
+                .willAnswer(invocation -> "https://example.com/" + invocation.getArgument(0));
+
+        // when
+        List<String> result = courseImageSelector.selectRandomImages(course);
+
+        // then
+        assertThat(result).hasSize(2);
+        verify(objectStorageService, times(2)).buildImageUrl(anyString());
+    }
+
+    @Test
+    @DisplayName("코스에 이미지가 3개 이상이면 최대 3개만 반환한다")
+    void selectRandomImages_WhenMoreThan3Images_Returns3Images() {
+        // given
+        Course course = createCourseWithPins(3, 2); // 3개의 핀, 각 핀에 2개의 이미지 (총 6개)
+
+        given(objectStorageService.buildImageUrl(anyString()))
+                .willAnswer(invocation -> "https://example.com/" + invocation.getArgument(0));
 
         // when
         List<String> result = courseImageSelector.selectRandomImages(course);
 
         // then
         assertThat(result).hasSize(3);
-        assertThat(result).allMatch(url -> url.endsWith(".jpg"));
+        verify(objectStorageService, times(3)).buildImageUrl(anyString());
     }
 
     @Test
-    @DisplayName("이미지가 3개 미만인 경우 모두 선택한다")
-    void success_if_image_count_less_than_3_all_choice() {
+    @DisplayName("코스에 이미지가 정확히 3개면 3개를 반환한다")
+    void selectRandomImages_WhenExactly3Images_Returns3Images() {
         // given
-        PinImage image1 = createPinImage("image1.jpg");
-        PinImage image2 = createPinImage("image2.jpg");
+        Course course = createCourseWithPins(3, 1); // 3개의 핀, 각 핀에 1개의 이미지
 
-        Pin pin = createPin(List.of(image1, image2));
-        Course course = createCourse(List.of(pin));
+        given(objectStorageService.buildImageUrl(anyString()))
+                .willAnswer(invocation -> "https://example.com/" + invocation.getArgument(0));
 
         // when
         List<String> result = courseImageSelector.selectRandomImages(course);
 
         // then
-        assertThat(result).hasSize(2);
-        assertThat(result).containsExactlyInAnyOrder("image1.jpg", "image2.jpg");
+        assertThat(result).hasSize(3);
+        verify(objectStorageService, times(3)).buildImageUrl(anyString());
     }
 
     @Test
-    @DisplayName("여러 핀의 이미지를 합쳐서 이미지를 선택한다.")
-    void success_merge_pin_to_choice_image() {
+    @DisplayName("핀 리스트가 비어있어도 예외 없이 빈 리스트를 반환한다")
+    void selectRandomImages_WhenEmptyPinList_ReturnsEmptyList() {
         // given
-        PinImage image1 = createPinImage("image1.jpg");
-        PinImage image2 = createPinImage("image2.jpg");
-
-        Pin pin1 = createPin(List.of(image1));
-        Pin pin2 = createPin(List.of(image2));
-
-        Course course = createCourse(List.of(pin1, pin2));
-
-        // when
-        List<String> result = courseImageSelector.selectRandomImages(course);
-
-        // then
-        assertThat(result).hasSize(2);
-    }
-
-    @Test
-    @DisplayName("이미지가 없는 경우 빈 리스트를 반환한다.")
-    void success_no_image_return_empty_list() {
-        // given
-        Pin pin = createPin(Collections.emptyList());
-        Course course = createCourse(List.of(pin));
+        Course course = Course.builder()
+                .id(1L)
+                .member(member)
+                .courseVisitDate(LocalDate.now())
+                .courseVisitMember("테스트 유저")
+                .courseRegion("서울")
+                .courseDescription("테스트 코스")
+                .pinList(new ArrayList<>())
+                .build();
 
         // when
         List<String> result = courseImageSelector.selectRandomImages(course);
@@ -93,21 +144,90 @@ class CourseImageSelectorTest {
         assertThat(result).isEmpty();
     }
 
-    private PinImage createPinImage(String url) {
-        PinImage image = mock(PinImage.class);
-        when(image.getImageUrl()).thenReturn(url);
-        return image;
+    @Test
+    @DisplayName("핀에 이미지가 없는 경우 빈 리스트를 반환한다")
+    void selectRandomImages_WhenPinsHaveNoImages_ReturnsEmptyList() {
+        // given
+        Course course = Course.builder()
+                .id(1L)
+                .member(member)
+                .courseVisitDate(LocalDate.now())
+                .courseVisitMember("테스트 유저")
+                .courseRegion("서울")
+                .courseDescription("테스트 코스")
+                .pinList(new ArrayList<>())
+                .build();
+
+        Pin pin = Pin.builder()
+                .id(1L)
+                .course(course)
+                .place(place)
+                .pinRating(BigDecimal.valueOf(4.0))
+                .pinPositive("좋아요")
+                .pinNegative("나빠요")
+                .pinImages(new ArrayList<>()) // 이미지 없음
+                .build();
+
+        course.addPin(pin);
+
+        // when
+        List<String> result = courseImageSelector.selectRandomImages(course);
+
+        // then
+        assertThat(result).isEmpty();
     }
 
-    private Pin createPin(List<PinImage> images) {
-        Pin pin = mock(Pin.class);
-        when(pin.getPinImages()).thenReturn(images);
-        return pin;
+    @Test
+    @DisplayName("여러 핀의 이미지를 합쳐서 처리한다")
+    void selectRandomImages_CombinesImagesFromMultiplePins() {
+        // given
+        Course course = createCourseWithPins(5, 2); // 5개의 핀, 각 핀에 2개의 이미지 (총 10개)
+
+        given(objectStorageService.buildImageUrl(anyString()))
+                .willAnswer(invocation -> "https://example.com/" + invocation.getArgument(0));
+
+        // when
+        List<String> result = courseImageSelector.selectRandomImages(course);
+
+        // then
+        assertThat(result).hasSize(3); // 최대 3개만 반환
+        assertThat(result).allMatch(url -> url.startsWith("https://example.com/"));
     }
 
-    private Course createCourse(List<Pin> pins) {
-        Course course = mock(Course.class);
-        when(course.getPinList()).thenReturn(pins);
+    private Course createCourseWithPins(int pinCount, int imageCountPerPin) {
+        Course course = Course.builder()
+                .id(1L)
+                .member(member)
+                .courseVisitDate(LocalDate.now())
+                .courseVisitMember("테스트 유저")
+                .courseRegion("서울")
+                .courseDescription("테스트 코스")
+                .pinList(new ArrayList<>())
+                .build();
+
+        for (int i = 0; i < pinCount; i++) {
+            Pin pin = Pin.builder()
+                    .id((long) (i + 1))
+                    .course(course)
+                    .place(place)
+                    .pinRating(BigDecimal.valueOf(4.0))
+                    .pinPositive("좋아요 " + i)
+                    .pinNegative("나빠요 " + i)
+                    .pinImages(new ArrayList<>())
+                    .build();
+
+            for (int j = 0; j < imageCountPerPin; j++) {
+                PinImage pinImage = PinImage.builder()
+                        .id((long) (i * imageCountPerPin + j + 1))
+                        .imageUrl("course/" + course.getId() + "/pin_" + i + "_image_" + j + ".jpg")
+                        .pin(pin)
+                        .build();
+                pin.addPinImage(pinImage);
+            }
+
+            course.addPin(pin);
+        }
+
         return course;
     }
 }


### PR DESCRIPTION
## 💡관련 이슈
<!-- 관련된 이슈를 연결해주세요 -->
Closes #105 

## 💼작업 설명
<!-- 실제로 진행한 작업을 간략히 요약해주세요 -->

## ✅구현/변경사항
<!-- 코드에서 구현/변경된 내용을 자세히 적어주세요 -->
- 
-

## 📝리뷰 요구사항
<!-- 논의사항/리뷰가 필요한 사항을 적어주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 코스 배너 썸네일 이미지 선택 로직 최적화
  * 배너 이미지 처리 방식 안정성 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->